### PR TITLE
Add per-build cache busting for shared assets

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,11 +21,12 @@
     <meta property="og:url" content="{{ canonical_url }}">
     <meta property="og:site_name" content="{{ site.name }}">
 
-    <link rel="stylesheet" href="{{ '/static/css/screen.css' | relative_url }}">
-    <link rel="stylesheet" href="{{ '/static/css/pygments.css' | relative_url }}">
+    {% capture asset_version %}{% if site.asset_version %}{{ site.asset_version }}{% elsif site.github.build_revision %}{{ site.github.build_revision }}{% else %}{{ site.time | date: '%Y%m%d%H%M%S' }}{% endif %}{% endcapture %}
+    <link rel="stylesheet" href="{{ '/static/css/screen.css' | relative_url }}?v={{ asset_version | strip }}">
+    <link rel="stylesheet" href="{{ '/static/css/pygments.css' | relative_url }}?v={{ asset_version | strip }}">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for danielfinch.co.uk" href="{{ '/words/feed/' | relative_url }}">
 
-    <script defer src="{{ '/static/js/scroll-progress.js' | relative_url }}"></script>
+    <script defer src="{{ '/static/js/scroll-progress.js' | relative_url }}?v={{ asset_version | strip }}"></script>
 </head>
 <body>
     <header class="site-header">


### PR DESCRIPTION
## Summary
- append a version token to shared CSS and header JS asset URLs
- prefer `site.asset_version`, then `site.github.build_revision`, then the local Jekyll build timestamp
- keep normal caching behavior while forcing fresh assets after each deploy

## Verification
- `bundle exec jekyll build`
